### PR TITLE
Fix lint errors in dist

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -9,6 +9,12 @@ export default tseslint.config(
   perfectionist.configs["recommended-alphabetical"],
   eslintConfigPrettier,
   {
-    ignores: ["**/*.js", "pnpm-lock.yaml"],
+    ignores: [
+      "**/*.js",
+      "**/*.d.ts",
+      "dist/**",
+      "node_modules/**",
+      "pnpm-lock.yaml",
+    ],
   },
 );


### PR DESCRIPTION
## Summary
- ignore dist and types in ESLint config

## Testing
- `npx vitest run`
- `npx tsc`
- `npx eslint .`